### PR TITLE
fix iphone plus dont show cross

### DIFF
--- a/MLDynamicModal/Classes/MLDynamicModalViewController.m
+++ b/MLDynamicModal/Classes/MLDynamicModalViewController.m
@@ -185,7 +185,7 @@ static const int kHorizontalMargin = 32;
     //NavigationBar
     [self.navBar autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:20.0f];
     [self.navBar autoPinEdgeToSuperviewEdge:ALEdgeLeft];
-    [self.navBar autoSetDimension:ALDimensionWidth toSize:44.0f];
+    [self.navBar autoSetDimension:ALDimensionWidth toSize:self.view.frame.size.width];
     [self.navBar autoSetDimension:ALDimensionHeight toSize:44.0f];
 }
 


### PR DESCRIPTION
En los iphone plus  la cruz no se muestra..

![image](https://user-images.githubusercontent.com/16806619/36440226-f6a1c2a2-164d-11e8-9f80-6ec433cc9dfe.png)

después (del fix)
![simulator screen shot - iphone 6 plus - 2018-02-20 at 14 56 09](https://user-images.githubusercontent.com/16806619/36440308-345a6374-164e-11e8-8a57-cddb9051912e.png)

![simulator screen shot - iphone 6s - 2018-02-20 at 14 55 28](https://user-images.githubusercontent.com/16806619/36440322-3f988b8a-164e-11e8-984b-db07cba11106.png)
