### PR TITLE
[IMPORTANT] Xcode 12 Migration [TRIVIAL]

### DIFF
--- a/MLDynamicModal.podspec
+++ b/MLDynamicModal.podspec
@@ -19,4 +19,7 @@ Pod::Spec.new do |s|
   s.dependency 'PureLayout'
   s.dependency 'FXBlurView'
   s.dependency 'MLUI'
+
+  s.pod_target_xcconfig = `xcodebuild -version` =~ /Xcode 12./ ? { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' } : { }
+
 end


### PR DESCRIPTION
# Xcode 12 ARM64 Migration
## Description

This is an automatic PR generated to fix a general issue introduced with the new Xcode 12. Please merge this PR before doing any other release to avoid breaking other teams' Pod.

This PR **is not a fully Xcode 12 migration**. You still need to migrate your Pod to be able to run in Xcode 12. **Remember you have time until 29/10/2020.** After that date, the entire app will be compiled with Xcode 12, so everything needs to be tested.

We created this [migration guide to help you](https://sites.google.com/mercadolibre.com/mobile/gu%C3%ADas-y-problemas/gu%C3%ADas-de-migraci%C3%B3n/migraci%C3%B3n-xcode-12).

## More Info...
During WWDC 2020, Apple presented a new mac that will run with an ARM processor (Apple Silicon). Nowadays, Mac has an Intel-based processor, with an x86_64 architecture but the new Apple Silicon is based on ARM64 architecture. Even though the new Macs are not available for purchase yet, Apple created Xcode 12 thinking on them. Since both architectures are not compatible, the new Xcode brings a new Simulator which is only designed to run on Apple Silicon.

Unfortunately, this change caused many frameworks to break. Frameworks are compiled for many architectures, but since ARM64 is new for Simulators, many framework's simulator slice don't have the architecture built-in. Frameworks such as Realm or Google Analytics are some examples.

When Xcode 12 tries to build in Release mode, it builds for every available architecture, including the new ARM64 Simulator architecture. There are many cases where our Pod depends on one of these previously mentions Pods with a missing architecture. So, while building it fails since there is no ARM64 Simulator slice of our dependency.

## Questions?
We have a [slack channel #help-ios-v14](https://meli.slack.com/archives/C0162P9396K) where you can contact us!


*Done with :heart: by Mobile Arch :smiley:*